### PR TITLE
feat(rust): support namekey in declaration component name props

### DIFF
--- a/packages/rust/src/components/associated-type.tsx
+++ b/packages/rust/src/components/associated-type.tsx
@@ -1,12 +1,13 @@
 import {
   Children,
   Declaration as CoreDeclaration,
+  Namekey,
   Refkey,
 } from "@alloy-js/core";
 import { createAssociatedTypeSymbol } from "../symbols/factories.js";
 
 export interface AssociatedTypeProps {
-  name: string;
+  name: string | Namekey;
   refkey?: Refkey;
   constraint?: Children;
   children?: Children;

--- a/packages/rust/src/components/const-declaration.tsx
+++ b/packages/rust/src/components/const-declaration.tsx
@@ -1,13 +1,14 @@
 import {
   Children,
   Declaration as CoreDeclaration,
+  Namekey,
   Refkey,
 } from "@alloy-js/core";
 import { createConstSymbol } from "../symbols/factories.js";
 import { toRustVisibility, toVisibilityPrefix } from "./visibility.js";
 
 export interface ConstDeclarationProps {
-  name: string;
+  name: string | Namekey;
   refkey?: Refkey;
   pub?: boolean;
   pub_crate?: boolean;

--- a/packages/rust/src/components/enum-declaration.tsx
+++ b/packages/rust/src/components/enum-declaration.tsx
@@ -3,6 +3,7 @@ import {
   Declaration as CoreDeclaration,
   For,
   Indent,
+  Namekey,
   Refkey,
   Scope,
   createScope,
@@ -18,7 +19,7 @@ import { TypeParameterProp, TypeParameters } from "./type-parameters.js";
 import { toRustVisibility, toVisibilityPrefix } from "./visibility.js";
 
 export interface EnumDeclarationProps {
-  name: string;
+  name: string | Namekey;
   refkey?: Refkey;
   pub?: boolean;
   pub_crate?: boolean;
@@ -31,7 +32,7 @@ export interface EnumDeclarationProps {
 }
 
 export interface EnumVariantProps {
-  name: string;
+  name: string | Namekey;
   refkey?: Refkey;
   doc?: string;
   kind?: "unit" | "tuple" | "struct";

--- a/packages/rust/src/components/function-declaration.tsx
+++ b/packages/rust/src/components/function-declaration.tsx
@@ -2,6 +2,7 @@ import {
   Children,
   Declaration as CoreDeclaration,
   Indent,
+  Namekey,
   Refkey,
   Scope,
   createScope,
@@ -27,7 +28,7 @@ import {
 import { toRustVisibility, toVisibilityPrefix } from "./visibility.js";
 
 export interface FunctionDeclarationProps {
-  name: string;
+  name: string | Namekey;
   refkey?: Refkey;
   pub?: boolean;
   pub_crate?: boolean;

--- a/packages/rust/src/components/static-declaration.tsx
+++ b/packages/rust/src/components/static-declaration.tsx
@@ -1,13 +1,14 @@
 import {
   Children,
   Declaration as CoreDeclaration,
+  Namekey,
   Refkey,
 } from "@alloy-js/core";
 import { createStaticSymbol } from "../symbols/factories.js";
 import { toRustVisibility, toVisibilityPrefix } from "./visibility.js";
 
 export interface StaticDeclarationProps {
-  name: string;
+  name: string | Namekey;
   refkey?: Refkey;
   pub?: boolean;
   pub_crate?: boolean;

--- a/packages/rust/src/components/struct-declaration.tsx
+++ b/packages/rust/src/components/struct-declaration.tsx
@@ -3,6 +3,7 @@ import {
   Declaration as CoreDeclaration,
   For,
   Indent,
+  Namekey,
   Refkey,
   Scope,
   createScope,
@@ -22,7 +23,7 @@ import {
 import { toRustVisibility, toVisibilityPrefix } from "./visibility.js";
 
 export interface StructDeclarationProps {
-  name: string;
+  name: string | Namekey;
   refkey?: Refkey;
   pub?: boolean;
   pub_crate?: boolean;
@@ -39,7 +40,7 @@ export interface StructDeclarationProps {
 }
 
 export interface FieldProps {
-  name: string;
+  name: string | Namekey;
   type: Children;
   refkey?: Refkey;
   pub?: boolean;

--- a/packages/rust/src/components/trait-declaration.tsx
+++ b/packages/rust/src/components/trait-declaration.tsx
@@ -5,6 +5,7 @@ import {
   createScope,
   For,
   Indent,
+  Namekey,
   Refkey,
   Scope,
 } from "@alloy-js/core";
@@ -19,7 +20,7 @@ import {
 import { toRustVisibility, toVisibilityPrefix } from "./visibility.js";
 
 export interface TraitDeclarationProps {
-  name: string;
+  name: string | Namekey;
   refkey?: Refkey;
   pub?: boolean;
   pub_crate?: boolean;

--- a/packages/rust/src/components/type-alias.tsx
+++ b/packages/rust/src/components/type-alias.tsx
@@ -1,6 +1,7 @@
 import {
   Children,
   Declaration as CoreDeclaration,
+  Namekey,
   Refkey,
 } from "@alloy-js/core";
 import { createTypeAliasSymbol } from "../symbols/factories.js";
@@ -8,7 +9,7 @@ import { TypeParameterProp, TypeParameters } from "./type-parameters.js";
 import { toRustVisibility, toVisibilityPrefix } from "./visibility.js";
 
 export interface TypeAliasProps {
-  name: string;
+  name: string | Namekey;
   refkey?: Refkey;
   pub?: boolean;
   pub_crate?: boolean;

--- a/packages/rust/src/symbols/factories.ts
+++ b/packages/rust/src/symbols/factories.ts
@@ -240,9 +240,9 @@ export function createTypeParameterSymbol(
   const scope = useRustScope();
   const typeParameterSpace =
     scope instanceof RustFunctionScope ? scope.typeParameters
-    : scope.ownerSymbol instanceof NamedTypeSymbol ?
-      scope.ownerSymbol.typeParameters
-    : undefined;
+      : scope.ownerSymbol instanceof NamedTypeSymbol ?
+        scope.ownerSymbol.typeParameters
+        : undefined;
 
   if (!typeParameterSpace) {
     throw new Error(

--- a/packages/rust/test/namekey.test.tsx
+++ b/packages/rust/test/namekey.test.tsx
@@ -1,0 +1,242 @@
+import { namekey, Output, refkey } from "@alloy-js/core";
+import "@alloy-js/core/testing";
+import { d } from "@alloy-js/core/testing";
+import { describe, expect, it } from "vitest";
+import {
+  ConstDeclaration,
+  CrateDirectory,
+  EnumDeclaration,
+  EnumVariant,
+  Field,
+  FunctionDeclaration,
+  ImplBlock,
+  Reference,
+  SourceFile,
+  StructDeclaration,
+  TraitDeclaration,
+  TypeAlias,
+} from "../src/components/index.js";
+import { findFile, toSourceTextMultiple } from "./utils.js";
+
+describe("namekey support", () => {
+  it("struct declaration with namekey as name", () => {
+    const personKey = namekey("Person");
+    expect(
+      <Output>
+        <CrateDirectory name="my_crate">
+          <SourceFile path="lib.rs">
+            <StructDeclaration name={personKey} pub>
+              <Field name="name" type="String" pub />
+            </StructDeclaration>
+          </SourceFile>
+        </CrateDirectory>
+      </Output>,
+    ).toRenderTo(d`
+      pub struct Person {
+        pub name: String,
+      }
+    `);
+  });
+
+  it("namekey enables cross-reference without explicit refkey", () => {
+    const personKey = namekey("Person");
+    expect(
+      <Output>
+        <CrateDirectory name="my_crate">
+          <SourceFile path="lib.rs">
+            <StructDeclaration name={personKey} pub>
+              <Field name="name" type="String" pub />
+            </StructDeclaration>
+            <hbr />
+            type Alias = <Reference refkey={personKey} />;
+          </SourceFile>
+        </CrateDirectory>
+      </Output>,
+    ).toRenderTo(d`
+      pub struct Person {
+        pub name: String,
+      }
+      type Alias = Person;
+    `);
+  });
+
+  it("namekey works for inline refkey resolution", () => {
+    const personKey = namekey("Person");
+    expect(
+      <Output>
+        <CrateDirectory name="my_crate">
+          <SourceFile path="lib.rs">
+            <StructDeclaration name={personKey} pub>
+              <Field name="name" type="String" pub />
+            </StructDeclaration>
+            <hbr />
+            type Alias = {personKey};
+          </SourceFile>
+        </CrateDirectory>
+      </Output>,
+    ).toRenderTo(d`
+      pub struct Person {
+        pub name: String,
+      }
+      type Alias = Person;
+    `);
+  });
+
+  it("namekey generates use statement across files", () => {
+    const personKey = namekey("Person");
+    const output = toSourceTextMultiple([
+      <SourceFile path="models.rs">
+        <StructDeclaration name={personKey} pub>
+          <Field name="name" type="String" pub />
+        </StructDeclaration>
+      </SourceFile>,
+      <SourceFile path="lib.rs">
+        type Alias = {personKey};
+      </SourceFile>,
+    ]);
+    const libFile = findFile(output, "lib.rs");
+    expect(libFile.contents).toContain("use crate::models::Person;");
+    expect(libFile.contents).toContain("type Alias = Person;");
+  });
+
+  it("enum declaration with namekey", () => {
+    const statusKey = namekey("Status");
+    expect(
+      <Output>
+        <CrateDirectory name="my_crate">
+          <SourceFile path="lib.rs">
+            <EnumDeclaration name={statusKey} pub>
+              <EnumVariant name="Active" />
+              <EnumVariant name="Inactive" />
+            </EnumDeclaration>
+          </SourceFile>
+        </CrateDirectory>
+      </Output>,
+    ).toRenderTo(d`
+      pub enum Status {
+        Active,
+        Inactive,
+      }
+    `);
+  });
+
+  it("trait declaration with namekey and cross-reference", () => {
+    const greetableKey = namekey("Greetable");
+    const personKey = namekey("Person");
+    expect(
+      <Output>
+        <CrateDirectory name="my_crate">
+          <SourceFile path="lib.rs">
+            <StructDeclaration name={personKey} pub />
+            <hbr />
+            <TraitDeclaration name={greetableKey} pub>
+              <FunctionDeclaration name="greet" receiver="&self" returnType="String" />
+            </TraitDeclaration>
+            <hbr />
+            <ImplBlock type={personKey} trait={greetableKey}>
+              <FunctionDeclaration name="greet" receiver="&self" returnType="String">
+                String::from("hello")
+              </FunctionDeclaration>
+            </ImplBlock>
+          </SourceFile>
+        </CrateDirectory>
+      </Output>,
+    ).toRenderTo(d`
+      pub struct Person {}
+      pub trait Greetable {
+        fn greet(&self) -> String;
+      }
+      impl Greetable for Person {
+        fn greet(&self) -> String {
+          String::from("hello")
+        }
+      }
+    `);
+  });
+
+  it("function declaration with namekey", () => {
+    const fnKey = namekey("do_stuff");
+    expect(
+      <Output>
+        <CrateDirectory name="my_crate">
+          <SourceFile path="lib.rs">
+            <FunctionDeclaration name={fnKey} pub receiver="none" returnType="bool">
+              true
+            </FunctionDeclaration>
+          </SourceFile>
+        </CrateDirectory>
+      </Output>,
+    ).toRenderTo(d`
+      pub fn do_stuff() -> bool {
+        true
+      }
+    `);
+  });
+
+  it("const declaration with namekey", () => {
+    const maxKey = namekey("MAX_RETRIES");
+    expect(
+      <Output>
+        <CrateDirectory name="my_crate">
+          <SourceFile path="lib.rs">
+            <ConstDeclaration name={maxKey} pub type="u32">5</ConstDeclaration>
+          </SourceFile>
+        </CrateDirectory>
+      </Output>,
+    ).toRenderTo(d`pub const MAX_RETRIES: u32 = 5;`);
+  });
+
+  it("type alias with namekey", () => {
+    const resultKey = namekey("AppResult");
+    expect(
+      <Output>
+        <CrateDirectory name="my_crate">
+          <SourceFile path="lib.rs">
+            <TypeAlias name={resultKey} pub>Result&lt;String, String&gt;</TypeAlias>
+          </SourceFile>
+        </CrateDirectory>
+      </Output>,
+    ).toRenderTo(d`pub type AppResult = Result<String, String>;`);
+  });
+
+  it("field with namekey", () => {
+    const nameField = namekey("user_name");
+    expect(
+      <Output>
+        <CrateDirectory name="my_crate">
+          <SourceFile path="lib.rs">
+            <StructDeclaration name="Config" pub>
+              <Field name={nameField} type="String" pub />
+            </StructDeclaration>
+          </SourceFile>
+        </CrateDirectory>
+      </Output>,
+    ).toRenderTo(d`
+      pub struct Config {
+        pub user_name: String,
+      }
+    `);
+  });
+
+  it("namekey with explicit refkey — both resolve to symbol", () => {
+    const explicitKey = refkey();
+    const nk = namekey("Foo");
+    expect(
+      <Output>
+        <CrateDirectory name="my_crate">
+          <SourceFile path="lib.rs">
+            <StructDeclaration name={nk} refkey={explicitKey} pub />
+            <hbr />
+            type A = <Reference refkey={explicitKey} />;
+            <hbr />
+            type B = {nk};
+          </SourceFile>
+        </CrateDirectory>
+      </Output>,
+    ).toRenderTo(d`
+      pub struct Foo {}
+      type A = Foo;
+      type B = Foo;
+    `);
+  });
+});


### PR DESCRIPTION
Widen the `name` prop from `string` to `string | Namekey` across all 8 declaration components (StructDeclaration, Field, EnumDeclaration, EnumVariant, FunctionDeclaration, TraitDeclaration, ConstDeclaration, StaticDeclaration, TypeAlias, AssociatedType).

This lets users pass a `namekey("Foo")` as the name prop, which both names the declaration and registers itself as a refkey — eliminating the need for a separate `refkey` prop. Core's OutputSymbol constructor already handles Namekey-to-refkey registration, so no factory changes were needed beyond a minor cleanup.